### PR TITLE
Fix deploy workflow: optimize-for-host step and regex dependency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Install Ansible
-        run: pip install ansible
+        run: pip install ansible regex
 
       - name: Optimize for host
         run: just optimize-for-host ${{ inputs.host }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install Ansible
         run: pip install ansible
 
+      - name: Optimize for host
+        run: just optimize-for-host ${{ inputs.host }}
+
       - name: Install Ansible roles
         run: just roles
 


### PR DESCRIPTION
## Summary

- Runs `optimize-for-host` after inventory checkout and before `just roles`
- Adds missing `regex` Python module to the pip install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)