### PR TITLE
Add Dayplanner role

### DIFF
--- a/roles/custom/dayplanner/defaults/main.yml
+++ b/roles/custom/dayplanner/defaults/main.yml
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+# Project source code URL: https://github.com/oliverlorenz/app-dayplanner
+
+dayplanner_enabled: true
+
+dayplanner_identifier: dayplanner
+dayplanner_base_path: "{{ mash_playbook_base_path }}/{{ dayplanner_identifier }}"
+
+# renovate: datasource=docker depName=ghcr.io/oliverlorenz/app-dayplanner versioning=semver
+dayplanner_version: latest
+
+dayplanner_uid: "{{ mash_playbook_uid }}"
+dayplanner_gid: "{{ mash_playbook_gid }}"
+
+# The hostname at which Dayplanner is served.
+dayplanner_hostname: ""
+
+# The path at which Dayplanner is served.
+# This value must either be `/` or not end with a slash (e.g. `/dayplanner`).
+dayplanner_path_prefix: /
+
+dayplanner_container_image: "{{ dayplanner_container_image_registry_prefix }}oliverlorenz/app-dayplanner:{{ dayplanner_container_image_tag }}"
+dayplanner_container_image_tag: "{{ dayplanner_version }}"
+dayplanner_container_image_registry_prefix: "{{ dayplanner_container_image_registry_prefix_upstream }}"
+dayplanner_container_image_registry_prefix_upstream: "{{ dayplanner_container_image_registry_prefix_upstream_default }}"
+dayplanner_container_image_registry_prefix_upstream_default: ghcr.io/
+dayplanner_container_image_force_pull: "{{ dayplanner_container_image_tag == 'latest' }}"
+
+# Controls whether the container exposes its HTTP port (tcp/80 in the container).
+#
+# Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8080"), or empty string to not expose.
+dayplanner_container_http_host_bind_port: ""
+
+# The base container network. It will be auto-created by this role if it doesn't exist already.
+dayplanner_container_network: "{{ dayplanner_identifier }}"
+
+# The port number in the container
+dayplanner_container_http_port: 80
+
+# A list of additional container networks that the container would be connected to.
+# The role does not create these networks, so make sure they already exist.
+# Use this to expose this container to another reverse proxy, which runs in a different container network.
+dayplanner_container_additional_networks: "{{ dayplanner_container_additional_networks_auto + dayplanner_container_additional_networks_custom }}"
+dayplanner_container_additional_networks_auto: []
+dayplanner_container_additional_networks_custom: []
+
+# A list of additional "volumes" to mount in the container.
+dayplanner_container_additional_volumes: "{{ dayplanner_container_additional_volumes_auto + dayplanner_container_additional_volumes_custom }}"
+dayplanner_container_additional_volumes_auto: []
+dayplanner_container_additional_volumes_custom: []
+
+# dayplanner_container_labels_traefik_enabled controls whether labels to assist a Traefik reverse-proxy will be attached to the container.
+# See `../templates/labels.j2` for details.
+#
+# To inject your own other container labels, see `dayplanner_container_labels_additional_labels`.
+dayplanner_container_labels_traefik_enabled: true
+dayplanner_container_labels_traefik_docker_network: "{{ dayplanner_container_network }}"
+dayplanner_container_labels_traefik_hostname: "{{ dayplanner_hostname }}"
+# The path prefix must either be `/` or not end with a slash (e.g. `/dayplanner`).
+dayplanner_container_labels_traefik_path_prefix: "{{ dayplanner_path_prefix }}"
+dayplanner_container_labels_traefik_rule: "Host(`{{ dayplanner_container_labels_traefik_hostname }}`){% if dayplanner_container_labels_traefik_path_prefix != '/' %} && PathPrefix(`{{ dayplanner_container_labels_traefik_path_prefix }}`){% endif %}"
+dayplanner_container_labels_traefik_priority: 0
+dayplanner_container_labels_traefik_entrypoints: web-secure
+dayplanner_container_labels_traefik_tls: "{{ dayplanner_container_labels_traefik_entrypoints != 'web' }}"
+dayplanner_container_labels_traefik_tls_certResolver: default  # noqa var-naming
+
+# Controls which additional headers to attach to all HTTP responses.
+# To add your own custom response headers, use `dayplanner_container_labels_traefik_additional_response_headers_custom`
+dayplanner_container_labels_traefik_additional_response_headers: "{{ dayplanner_container_labels_traefik_additional_response_headers_auto | combine(dayplanner_container_labels_traefik_additional_response_headers_custom) }}"
+dayplanner_container_labels_traefik_additional_response_headers_auto: |
+  {{
+    {}
+    | combine ({'X-XSS-Protection': dayplanner_http_header_xss_protection} if dayplanner_http_header_xss_protection else {})
+    | combine ({'X-Content-Type-Options': dayplanner_http_header_content_type_options} if dayplanner_http_header_content_type_options else {})
+    | combine ({'Content-Security-Policy': dayplanner_http_header_content_security_policy} if dayplanner_http_header_content_security_policy else {})
+    | combine ({'Permissions-Policy': dayplanner_http_header_permissions_policy} if dayplanner_http_header_permissions_policy else {})
+    | combine ({'Strict-Transport-Security': dayplanner_http_header_strict_transport_security} if dayplanner_http_header_strict_transport_security and dayplanner_container_labels_traefik_tls else {})
+  }}
+dayplanner_container_labels_traefik_additional_response_headers_custom: {}
+
+# dayplanner_container_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
+# See `../templates/labels.j2` for details.
+dayplanner_container_labels_additional_labels: "{{ dayplanner_container_labels_additional_labels_auto + dayplanner_container_labels_additional_labels_custom }}"
+dayplanner_container_labels_additional_labels_auto: []
+dayplanner_container_labels_additional_labels_custom: []
+
+# A list of extra arguments to pass to the container (`docker create` command)
+dayplanner_container_extra_arguments: "{{ dayplanner_container_extra_arguments_auto + dayplanner_container_extra_arguments_custom }}"
+dayplanner_container_extra_arguments_auto: []
+dayplanner_container_extra_arguments_custom: []
+
+# Specifies the value of the `X-XSS-Protection` header
+dayplanner_http_header_xss_protection: "1; mode=block"
+
+# Specifies the value of the `X-Content-Type-Options` header.
+dayplanner_http_header_content_type_options: nosniff
+
+# Specifies the value of the `Content-Security-Policy` header.
+dayplanner_http_header_content_security_policy: frame-ancestors 'self'
+
+# Specifies the value of the `Permissions-Policy` header.
+dayplanner_http_header_permissions_policy: "{{ 'interest-cohort=()' if dayplanner_floc_optout_enabled else '' }}"
+
+# Specifies the value of the `Strict-Transport-Security` header.
+dayplanner_http_header_strict_transport_security: "max-age=31536000; includeSubDomains{{ '; preload' if dayplanner_hsts_preload_enabled else '' }}"
+
+dayplanner_floc_optout_enabled: true
+dayplanner_hsts_preload_enabled: false
+
+# List of systemd services that the Dayplanner systemd service depends on
+dayplanner_systemd_required_services_list: "{{ dayplanner_systemd_required_services_list_default + dayplanner_systemd_required_services_list_auto + dayplanner_systemd_required_services_list_custom }}"
+dayplanner_systemd_required_services_list_default: "{{ [devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [] }}"
+dayplanner_systemd_required_services_list_auto: []
+dayplanner_systemd_required_services_list_custom: []
+
+# List of systemd services that the Dayplanner systemd service wants
+dayplanner_systemd_wanted_services_list: "{{ dayplanner_systemd_wanted_services_list_default + dayplanner_systemd_wanted_services_list_auto + dayplanner_systemd_wanted_services_list_custom }}"
+dayplanner_systemd_wanted_services_list_default: []
+dayplanner_systemd_wanted_services_list_auto: []
+dayplanner_systemd_wanted_services_list_custom: []

--- a/roles/custom/dayplanner/tasks/install.yml
+++ b/roles/custom/dayplanner/tasks/install.yml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+- name: Ensure Dayplanner paths exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0750"
+    owner: "{{ dayplanner_uid }}"
+    group: "{{ dayplanner_gid }}"
+  with_items:
+    - "{{ dayplanner_base_path }}"
+
+- name: Ensure Dayplanner support files installed
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/{{ item }}.j2"
+    dest: "{{ dayplanner_base_path }}/{{ item }}"
+    mode: "0640"
+    owner: "{{ dayplanner_uid }}"
+    group: "{{ dayplanner_gid }}"
+  with_items:
+    - labels
+
+- name: Ensure Dayplanner container image is pulled via community.docker.docker_image
+  when: devture_systemd_docker_base_container_image_pull_method == 'ansible-module'
+  community.docker.docker_image:
+    name: "{{ dayplanner_container_image }}"
+    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
+    force_source: "{{ dayplanner_container_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else dayplanner_container_image_force_pull }}"
+  register: result
+  retries: "{{ devture_playbook_help_container_retries_count }}"
+  delay: "{{ devture_playbook_help_container_retries_delay }}"
+  until: result is not failed
+
+- name: Ensure Dayplanner container image is pulled via ansible.builtin.command
+  when: devture_systemd_docker_base_container_image_pull_method == 'command'
+  ansible.builtin.command:
+    cmd: "{{ devture_systemd_docker_base_host_command_docker }} pull {{ dayplanner_container_image }}"
+  register: result
+  retries: "{{ devture_playbook_help_container_retries_count }}"
+  delay: "{{ devture_playbook_help_container_retries_delay }}"
+  until: result is not failed
+  changed_when: "'Downloaded newer image' in result.stdout"
+
+- name: Ensure Dayplanner container network is created via community.docker.docker_network
+  when: devture_systemd_docker_base_container_network_creation_method == 'ansible-module'
+  community.docker.docker_network:
+    enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
+    name: "{{ dayplanner_container_network }}"
+    driver: bridge
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
+
+- name: Ensure Dayplanner container network is created via ansible.builtin.command
+  when: devture_systemd_docker_base_container_network_creation_method == 'command'
+  ansible.builtin.command:
+    cmd: >-
+      {{ devture_systemd_docker_base_host_command_docker }} network create
+      {% if devture_systemd_docker_base_ipv6_enabled %}--ipv6{% endif %}
+      {{ devture_systemd_docker_base_container_networks_driver_options_string }}
+      {{ dayplanner_container_network }}
+  register: network_creation_result
+  changed_when: network_creation_result.rc == 0
+  failed_when: network_creation_result.rc != 0 and 'already exists' not in network_creation_result.stderr
+
+- name: Ensure Dayplanner systemd service is present
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/systemd/dayplanner.service.j2"
+    dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ dayplanner_identifier }}.service"
+    mode: "0644"

--- a/roles/custom/dayplanner/tasks/main.yml
+++ b/roles/custom/dayplanner/tasks/main.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+- name: Perform Dayplanner installation tasks
+  when: dayplanner_enabled | bool
+  tags:
+    - setup-all
+    - setup-dayplanner
+    - install-all
+    - install-dayplanner
+  block:
+    - name: Validate Dayplanner configuration
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/validate_config.yml"
+    - name: Install Dayplanner
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/install.yml"
+
+- name: Perform Dayplanner uninstallation tasks
+  when: not dayplanner_enabled | bool
+  tags:
+    - setup-all
+    - setup-dayplanner
+  block:
+    - name: Uninstall Dayplanner
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/uninstall.yml"

--- a/roles/custom/dayplanner/tasks/uninstall.yml
+++ b/roles/custom/dayplanner/tasks/uninstall.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+- name: Check existence of Dayplanner systemd service
+  ansible.builtin.stat:
+    path: "{{ devture_systemd_docker_base_systemd_path }}/{{ dayplanner_identifier }}.service"
+  register: dayplanner_service_stat
+
+- name: Uninstall Dayplanner systemd services and files
+  when: dayplanner_service_stat.stat.exists | bool
+  block:
+    - name: Ensure Dayplanner systemd service is stopped
+      ansible.builtin.service:
+        name: "{{ dayplanner_identifier }}"
+        state: stopped
+        enabled: false
+        daemon_reload: true
+
+    - name: Ensure Dayplanner systemd service does not exist
+      ansible.builtin.file:
+        path: "{{ devture_systemd_docker_base_systemd_path }}/{{ dayplanner_identifier }}.service"
+        state: absent
+
+    - name: Ensure Dayplanner container network does not exist via community.docker.docker_network
+      when: devture_systemd_docker_base_container_network_creation_method == 'ansible-module'
+      community.docker.docker_network:
+        name: "{{ dayplanner_container_network }}"
+        state: absent
+
+    - name: Ensure Dayplanner container network does not exist via ansible.builtin.command
+      when: devture_systemd_docker_base_container_network_creation_method == 'command'
+      ansible.builtin.command:
+        cmd: >-
+          {{ devture_systemd_docker_base_host_command_docker }} network rm
+          {{ dayplanner_container_network }}
+      register: network_deletion_result
+      changed_when: dayplanner_container_network in network_deletion_result.stdout
+
+    - name: Ensure Dayplanner path does not exist
+      ansible.builtin.file:
+        path: "{{ dayplanner_base_path }}"
+        state: absent

--- a/roles/custom/dayplanner/tasks/validate_config.yml
+++ b/roles/custom/dayplanner/tasks/validate_config.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+- name: Run if Traefik is enabled
+  when: dayplanner_container_labels_traefik_enabled | bool
+  block:
+    - name: Fail if Traefik settings required for Dayplanner are not defined
+      ansible.builtin.fail:
+        msg: >-
+          You need to define a required configuration setting (`{{ item }}`).
+      when: "lookup('vars', item, default='') | string | length == 0"
+      with_items:
+        - dayplanner_container_labels_traefik_hostname
+        - dayplanner_container_labels_traefik_path_prefix
+
+    - name: Fail if dayplanner_container_labels_traefik_path_prefix ends with a slash
+      ansible.builtin.fail:
+        msg: >-
+          dayplanner_container_labels_traefik_path_prefix (`{{ dayplanner_container_labels_traefik_path_prefix }}`) must either be `/` or not end with a slash (e.g. `/dayplanner`).
+      when: "dayplanner_container_labels_traefik_path_prefix != '/' and dayplanner_container_labels_traefik_path_prefix[-1] == '/'"

--- a/roles/custom/dayplanner/templates/labels.j2
+++ b/roles/custom/dayplanner/templates/labels.j2
@@ -1,0 +1,53 @@
+{#
+SPDX-FileCopyrightText: 2026 Oliver Lorenz
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
+{% if dayplanner_container_labels_traefik_enabled %}
+traefik.enable=true
+
+{% if dayplanner_container_labels_traefik_docker_network %}
+traefik.docker.network={{ dayplanner_container_labels_traefik_docker_network }}
+{% endif %}
+
+{% set middlewares = [] %}
+
+{% if dayplanner_container_labels_traefik_path_prefix != '/' %}
+traefik.http.middlewares.{{ dayplanner_identifier }}-slashless-redirect.redirectregex.regex=^({{ dayplanner_container_labels_traefik_path_prefix | quote }})$
+traefik.http.middlewares.{{ dayplanner_identifier }}-slashless-redirect.redirectregex.replacement=${1}/
+{% set middlewares = middlewares + [dayplanner_identifier + '-slashless-redirect'] %}
+{% endif %}
+
+{% if dayplanner_container_labels_traefik_path_prefix != '/' %}
+traefik.http.middlewares.{{ dayplanner_identifier }}-strip-prefix.stripprefix.prefixes={{ dayplanner_container_labels_traefik_path_prefix }}
+{% set middlewares = middlewares + [dayplanner_identifier + '-strip-prefix'] %}
+{% endif %}
+
+{% if dayplanner_container_labels_traefik_additional_response_headers.keys() | length > 0 %}
+{% for name, value in dayplanner_container_labels_traefik_additional_response_headers.items() %}
+traefik.http.middlewares.{{ dayplanner_identifier }}-add-response-headers.headers.customresponseheaders.{{ name }}={{ value }}
+{% endfor %}
+{% set middlewares = middlewares + [dayplanner_identifier + '-add-response-headers'] %}
+{% endif %}
+
+traefik.http.routers.{{ dayplanner_identifier }}.rule={{ dayplanner_container_labels_traefik_rule }}
+{% if dayplanner_container_labels_traefik_priority | int > 0 %}
+traefik.http.routers.{{ dayplanner_identifier }}.priority={{ dayplanner_container_labels_traefik_priority }}
+{% endif %}
+traefik.http.routers.{{ dayplanner_identifier }}.service={{ dayplanner_identifier }}
+{% if middlewares | length > 0 %}
+traefik.http.routers.{{ dayplanner_identifier }}.middlewares={{ middlewares | join(',') }}
+{% endif %}
+traefik.http.routers.{{ dayplanner_identifier }}.entrypoints={{ dayplanner_container_labels_traefik_entrypoints }}
+traefik.http.routers.{{ dayplanner_identifier }}.tls={{ dayplanner_container_labels_traefik_tls | to_json }}
+{% if dayplanner_container_labels_traefik_tls %}
+traefik.http.routers.{{ dayplanner_identifier }}.tls.certResolver={{ dayplanner_container_labels_traefik_tls_certResolver }}
+{% endif %}
+
+traefik.http.services.{{ dayplanner_identifier }}.loadbalancer.server.port={{ dayplanner_container_http_port }}
+{% endif %}
+
+{% for arg in dayplanner_container_labels_additional_labels %}
+{{ arg }}
+{% endfor %}

--- a/roles/custom/dayplanner/templates/systemd/dayplanner.service.j2
+++ b/roles/custom/dayplanner/templates/systemd/dayplanner.service.j2
@@ -1,0 +1,55 @@
+{#
+SPDX-FileCopyrightText: 2026 Oliver Lorenz
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
+[Unit]
+Description=Dayplanner ({{ dayplanner_identifier }})
+{% for service in dayplanner_systemd_required_services_list %}
+Requires={{ service }}
+After={{ service }}
+{% endfor %}
+{% for service in dayplanner_systemd_wanted_services_list %}
+Wants={{ service }}
+{% endfor %}
+DefaultDependencies=no
+
+[Service]
+Type=simple
+Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ dayplanner_identifier }} 2>/dev/null || true'
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ dayplanner_identifier }} 2>/dev/null || true'
+
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
+      --rm \
+      --name={{ dayplanner_identifier }} \
+      --log-driver=none \
+      --network={{ dayplanner_container_network }} \
+      {% if dayplanner_container_http_host_bind_port %}
+      -p {{ dayplanner_container_http_host_bind_port }}:{{ dayplanner_container_http_port }} \
+      {% endif %}
+      --label-file={{ dayplanner_base_path }}/labels \
+      {% for volume in dayplanner_container_additional_volumes %}
+      --mount type={{ volume.type | default('bind' if '/' in volume.src else 'volume') }},src={{ volume.src }},dst={{ volume.dst }}{{ (',' + volume.options) if volume.options else '' }} \
+      {% endfor %}
+      {% for arg in dayplanner_container_extra_arguments %}
+      {{ arg }} \
+      {% endfor %}
+      {{ dayplanner_container_image }}
+
+{% for network in dayplanner_container_additional_networks %}
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ dayplanner_identifier }}
+{% endfor %}
+
+ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ dayplanner_identifier }}
+
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ dayplanner_identifier }} 2>/dev/null || true'
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ dayplanner_identifier }} 2>/dev/null || true'
+
+Restart=always
+RestartSec=30
+SyslogIdentifier={{ dayplanner_identifier }}
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -258,6 +258,10 @@
     - role: galaxy/databasus
     # /role-specific:databasus
 
+    # role-specific:dayplanner
+    - role: custom/dayplanner
+    # /role-specific:dayplanner
+
     # role-specific:ddclient
     - role: galaxy/ddclient
     # /role-specific:ddclient


### PR DESCRIPTION
## Summary

- Adds `roles/custom/dayplanner` — an Ansible role for self-hosting [app-dayplanner](https://github.com/oliverlorenz/app-dayplanner), a mobile-first PWA weekly planner served via nginx
- Registers the role in `templates/setup.yml` (alphabetically between `ddclient` and `databasus`)
- Supports Traefik reverse-proxy with TLS, optional subpath routing, and configurable HTTP security headers
- Stateless app (no volumes, no environment variables required)

## Test plan

- [ ] `just setup-service dayplanner <host>` installs and starts the service
- [ ] Service is reachable via Traefik at the configured hostname
- [ ] `dayplanner_enabled: false` triggers clean uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)