### PR TITLE
fix: resolve SSH host key verification failure in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,8 @@ jobs:
   deploy:
     name: Deploy (${{ inputs.mode }})
     runs-on: ubuntu-latest
+    env:
+      ANSIBLE_HOST_KEY_CHECKING: "False"
     steps:
       - uses: actions/checkout@v4
 
@@ -60,7 +62,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "${{ inputs.host }}" >> ~/.ssh/known_hosts
+          ssh-keyscan -H "${{ inputs.host }}" | tee -a ~/.ssh/known_hosts
 
       - name: Write secrets
         run: |


### PR DESCRIPTION
Disable Ansible host key checking in CI via ANSIBLE_HOST_KEY_CHECKING env var and improve ssh-keyscan visibility with tee instead of silent append.