### PR TITLE
feat: add passlib to Ansible pip install in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Install Ansible
-        run: pip install ansible regex
+        run: pip install ansible regex passlib
 
       - name: Optimize for host
         run: just optimize-for-host ${{ inputs.host }}


### PR DESCRIPTION
## Summary

- Adds `passlib` to the `pip install` step in the GitHub Actions deploy workflow
- The `Dockerfile` already installs `py3-passlib` via `apk add`, this brings parity to the GHA deploy path

## Test plan

- [ ] Trigger a deploy workflow and verify no `passlib` import errors occur during Ansible execution

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbPsSC18fYgTj3U8fqMBAv)_