### PR TITLE
adds app-dooropener custom role

### DIFF
--- a/roles/custom/app-dooropener/README.md
+++ b/roles/custom/app-dooropener/README.md
@@ -1,0 +1,29 @@
+<!--
+SPDX-FileCopyrightText: 2026 Oliver Lorenz
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# app-dooropener Ansible role
+
+This is an [Ansible](https://www.ansible.com/) role which installs the [Dooropener PWA](https://github.com/oliverlorenz/app-dooropener) to run as a [Docker](https://www.docker.com/) container wrapped in a systemd service.
+
+This role *implicitly* depends on:
+
+- [`com.devture.ansible.role.playbook_help`](https://github.com/devture/com.devture.ansible.role.playbook_help)
+- [`com.devture.ansible.role.systemd_docker_base`](https://github.com/devture/com.devture.ansible.role.systemd_docker_base)
+
+Check [defaults/main.yml](defaults/main.yml) for the full list of supported options.
+
+## Configuration
+
+At minimum you need to set:
+
+- `app_dooropener_hostname` — the hostname the PWA is served at
+- `app_dooropener_config_home_assistant_base_url` — the HomeAssistant base URL (e.g. `https://api.example.com`)
+- `app_dooropener_environment_homeassistant_token` — a HomeAssistant long-lived access token
+- `app_dooropener_config_doors` — the list of doors, scripts and time-boxed PINs (see the example in [defaults/main.yml](defaults/main.yml))
+
+`app_dooropener_environment_homeassistant_token` and `app_dooropener_config_doors` contain secrets, so define them in an ansible-vault-encrypted file (e.g. `inventory/host_vars/<server>/vault.yml`), not in plain `group_vars`.
+
+The doors/PINs are rendered into `config.json` and bind-mounted read-only into the container. To rotate PINs, update `app_dooropener_config_doors` and re-run the playbook (`just setup-service app-dooropener <server>` or similar) — no image rebuild is required, only a container restart.

--- a/roles/custom/app-dooropener/REUSE.toml
+++ b/roles/custom/app-dooropener/REUSE.toml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+version = 1
+
+# Computer-generated files and other files which cannot be copyrighted
+[[annotations]]
+path = [
+    "meta/main.yml"
+]
+SPDX-FileCopyrightText = "NONE"
+SPDX-License-Identifier = "CC0-1.0"

--- a/roles/custom/app-dooropener/defaults/main.yml
+++ b/roles/custom/app-dooropener/defaults/main.yml
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+# Project source code URL: https://github.com/oliverlorenz/app-dooropener
+
+app_dooropener_enabled: true
+
+app_dooropener_identifier: app-dooropener
+app_dooropener_base_path: "{{ mash_playbook_base_path }}/{{ app_dooropener_identifier }}"
+
+app_dooropener_container_image: "ghcr.io/oliverlorenz/app-dooropener:latest"
+app_dooropener_container_image_force_pull: true
+
+app_dooropener_container_image_registry_login_server: ghcr.io
+app_dooropener_container_image_registry_username: ""
+app_dooropener_container_image_registry_password: ""
+
+# HomeAssistant long-lived access token used to trigger the door-opening scripts.
+# The token is written to the container's env-file and never logged.
+app_dooropener_environment_homeassistant_token: ""
+
+# Additional environment variables to pass to the container.
+app_dooropener_environment_variables_additional_variables: ""
+
+# Controls whether the container exposes its HTTP port (tcp/3000 in the container).
+#
+# Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:3000"), or empty string to not expose.
+app_dooropener_container_http_host_bind_port: ""
+
+# The base container network. It will be auto-created by this role if it doesn't exist already.
+app_dooropener_container_network: "{{ app_dooropener_identifier }}"
+
+# The port number in the container
+app_dooropener_container_http_port: 3000
+
+# The hostname at which the PWA is served.
+app_dooropener_hostname: ""
+
+# The path at which the PWA is exposed.
+# This value must either be `/` or not end with a slash (e.g. `/dooropener`).
+app_dooropener_path_prefix: /
+
+# The path (inside the container) that the app reads its `config.json` (doors/PINs) from.
+app_dooropener_container_config_path: /config/config.json
+
+# The HomeAssistant base URL that the container calls to trigger door-opening scripts
+# (`config.json`'s `homeAssistantBaseUrl`).
+app_dooropener_config_home_assistant_base_url: ""
+
+# A list of doors, each with its own HomeAssistant scriptId and time-boxed PINs.
+# This is rendered into `config.json` (see `../templates/config.json.j2`) and mounted
+# read-only into the container, so PINs can be rotated by re-running the playbook
+# (container restart only, no image rebuild).
+#
+# Example:
+#   app_dooropener_config_doors:
+#     - doorId: haustuer
+#       scriptId: script.open_haustuer
+#       pins:
+#         - pin: "1234"
+#           validFrom: "2026-01-01T00:00:00.000Z"
+#           validUntil: "2026-12-31T23:59:59.000Z"
+#
+# This typically contains secrets (the PINs), so define it in an ansible-vault-encrypted
+# file (e.g. `inventory/host_vars/<server>/vault.yml`).
+app_dooropener_config_doors: []
+
+# A list of additional container networks that the container would be connected to.
+# The role does not create these networks, so make sure they already exist.
+# Use this to expose this container to another reverse proxy, which runs in a different container network.
+app_dooropener_container_additional_networks: "{{ app_dooropener_container_additional_networks_auto + app_dooropener_container_additional_networks_custom }}"
+app_dooropener_container_additional_networks_auto: []
+app_dooropener_container_additional_networks_custom: []
+
+# A list of additional "volumes" to mount in the container.
+# Contains definition objects like this: `{"type": "bind", "src": "/outside", "dst": "/inside", "options": "readonly"}.
+app_dooropener_container_additional_volumes: "{{ app_dooropener_container_additional_volumes_auto + app_dooropener_container_additional_volumes_custom }}"
+app_dooropener_container_additional_volumes_auto:
+  - type: bind
+    src: "{{ app_dooropener_base_path }}/config.json"
+    dst: "{{ app_dooropener_container_config_path }}"
+    options: ro
+app_dooropener_container_additional_volumes_custom: []
+
+# A list of extra arguments to pass to the container (`docker run` command)
+app_dooropener_container_extra_arguments: []
+
+# app_dooropener_container_labels_traefik_enabled controls whether labels to assist a Traefik reverse-proxy will be attached to the container.
+# See `../templates/labels.j2` for details.
+#
+# To inject your own other container labels, see `app_dooropener_container_labels_additional_labels`.
+app_dooropener_container_labels_traefik_enabled: true
+app_dooropener_container_labels_traefik_docker_network: "{{ app_dooropener_container_network }}"
+app_dooropener_container_labels_traefik_hostname: "{{ app_dooropener_hostname }}"
+# The path prefix must either be `/` or not end with a slash (e.g. `/dooropener`).
+app_dooropener_container_labels_traefik_path_prefix: "{{ app_dooropener_path_prefix }}"
+app_dooropener_container_labels_traefik_rule: "Host(`{{ app_dooropener_container_labels_traefik_hostname }}`)"
+app_dooropener_container_labels_traefik_priority: 0
+app_dooropener_container_labels_traefik_entrypoints: web-secure
+app_dooropener_container_labels_traefik_tls: "{{ app_dooropener_container_labels_traefik_entrypoints != 'web' }}"
+app_dooropener_container_labels_traefik_tls_certResolver: default  # noqa var-naming
+
+# Controls which additional headers to attach to all HTTP requests.
+# To add your own custom request headers, use `app_dooropener_container_labels_traefik_additional_request_headers_custom`
+app_dooropener_container_labels_traefik_additional_request_headers: "{{ app_dooropener_container_labels_traefik_additional_request_headers_auto | combine(app_dooropener_container_labels_traefik_additional_request_headers_custom) }}"
+app_dooropener_container_labels_traefik_additional_request_headers_auto: {}
+app_dooropener_container_labels_traefik_additional_request_headers_custom: {}
+
+# Controls which additional headers to attach to all HTTP responses.
+# To add your own custom response headers, use `app_dooropener_container_labels_traefik_additional_response_headers_custom`
+app_dooropener_container_labels_traefik_additional_response_headers: "{{ app_dooropener_container_labels_traefik_additional_response_headers_auto | combine(app_dooropener_container_labels_traefik_additional_response_headers_custom) }}"
+app_dooropener_container_labels_traefik_additional_response_headers_auto: |
+  {{
+    {}
+    | combine ({'X-XSS-Protection': app_dooropener_http_header_xss_protection} if app_dooropener_http_header_xss_protection else {})
+    | combine ({'X-Content-Type-Options': app_dooropener_http_header_content_type_options} if app_dooropener_http_header_content_type_options else {})
+    | combine ({'Content-Security-Policy': app_dooropener_http_header_content_security_policy} if app_dooropener_http_header_content_security_policy else {})
+    | combine ({'Permissions-Policy': app_dooropener_http_header_permissions_policy} if app_dooropener_http_header_permissions_policy else {})
+    | combine ({'Strict-Transport-Security': app_dooropener_http_header_strict_transport_security} if app_dooropener_http_header_strict_transport_security and app_dooropener_container_labels_traefik_tls else {})
+  }}
+app_dooropener_container_labels_traefik_additional_response_headers_custom: {}
+
+# app_dooropener_container_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
+# See `../templates/labels.j2` for details.
+app_dooropener_container_labels_additional_labels: ""
+
+# Specifies the value of the `X-XSS-Protection` header
+app_dooropener_http_header_xss_protection: "1; mode=block"
+
+# Specifies the value of the `X-Content-Type-Options` header.
+app_dooropener_http_header_content_type_options: nosniff
+
+# Specifies the value of the `Content-Security-Policy` header.
+app_dooropener_http_header_content_security_policy: frame-ancestors 'self'
+
+# Specifies the value of the `Permissions-Policy` header.
+app_dooropener_http_header_permissions_policy: "{{ 'interest-cohort=()' if app_dooropener_floc_optout_enabled else '' }}"
+
+# Specifies the value of the `Strict-Transport-Security` header.
+app_dooropener_http_header_strict_transport_security: "max-age=31536000; includeSubDomains{{ '; preload' if app_dooropener_hsts_preload_enabled else '' }}"
+
+app_dooropener_floc_optout_enabled: true
+app_dooropener_hsts_preload_enabled: false
+
+# List of systemd services that the app-dooropener systemd service depends on
+app_dooropener_systemd_required_services_list: "{{ app_dooropener_systemd_required_services_list_default + app_dooropener_systemd_required_services_list_auto + app_dooropener_systemd_required_services_list_custom }}"
+app_dooropener_systemd_required_services_list_default: "{{ [devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [] }}"
+app_dooropener_systemd_required_services_list_auto: []
+app_dooropener_systemd_required_services_list_custom: []
+
+# List of systemd services that the app-dooropener systemd service wants
+app_dooropener_systemd_wanted_services_list: "{{ app_dooropener_systemd_wanted_services_list_default + app_dooropener_systemd_wanted_services_list_auto + app_dooropener_systemd_wanted_services_list_custom }}"
+app_dooropener_systemd_wanted_services_list_default: []
+app_dooropener_systemd_wanted_services_list_auto: []
+app_dooropener_systemd_wanted_services_list_custom: []

--- a/roles/custom/app-dooropener/meta/main.yml
+++ b/roles/custom/app-dooropener/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  author: Oliver Lorenz
+  role_name: app_dooropener
+  namespace: oliverlorenz
+  description: Dooropener PWA
+  platforms:
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+    - name: ArchLinux
+      versions:
+        - all
+    - name: EL
+      versions:
+        - all
+  license: AGPL-3.0-or-later
+  min_ansible_version: "2.1"

--- a/roles/custom/app-dooropener/tasks/install.yml
+++ b/roles/custom/app-dooropener/tasks/install.yml
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+- name: Ensure app-dooropener path exists
+  ansible.builtin.file:
+    path: "{{ app_dooropener_base_path }}"
+    state: directory
+    mode: "0750"
+    owner: "{{ app_dooropener_uid }}"
+    group: "{{ app_dooropener_gid }}"
+
+- name: Ensure app-dooropener support files installed
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/{{ item }}.j2"
+    dest: "{{ app_dooropener_base_path }}/{{ item }}"
+    mode: "0640"
+    owner: "{{ app_dooropener_uid }}"
+    group: "{{ app_dooropener_gid }}"
+  with_items:
+    - env
+    - labels
+    - config.json
+
+- name: Log in to container image registry
+  when: app_dooropener_container_image_registry_username != '' and app_dooropener_container_image_registry_password != ''
+  community.docker.docker_login:
+    registry_url: "{{ app_dooropener_container_image_registry_login_server }}"
+    username: "{{ app_dooropener_container_image_registry_username }}"
+    password: "{{ app_dooropener_container_image_registry_password }}"
+
+- name: Ensure app-dooropener container image is pulled via community.docker.docker_image
+  when: devture_systemd_docker_base_container_image_pull_method == 'ansible-module'
+  community.docker.docker_image:
+    name: "{{ app_dooropener_container_image }}"
+    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
+    force_source: "{{ app_dooropener_container_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else app_dooropener_container_image_force_pull }}"
+  register: result
+  retries: "{{ devture_playbook_help_container_retries_count }}"
+  delay: "{{ devture_playbook_help_container_retries_delay }}"
+  until: result is not failed
+
+- name: Ensure app-dooropener container image is pulled via ansible.builtin.command
+  when: devture_systemd_docker_base_container_image_pull_method == 'command'
+  ansible.builtin.command:
+    cmd: "{{ devture_systemd_docker_base_host_command_docker }} pull {{ app_dooropener_container_image }}"
+  register: result
+  retries: "{{ devture_playbook_help_container_retries_count }}"
+  delay: "{{ devture_playbook_help_container_retries_delay }}"
+  until: result is not failed
+  changed_when: "'Downloaded newer image' in result.stdout"
+
+- name: Ensure app-dooropener container network is created via community.docker.docker_network
+  when: devture_systemd_docker_base_container_network_creation_method == 'ansible-module'
+  community.docker.docker_network:
+    enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
+    name: "{{ app_dooropener_container_network }}"
+    driver: bridge
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
+
+- name: Ensure app-dooropener container network is created via ansible.builtin.command
+  when: devture_systemd_docker_base_container_network_creation_method == 'command'
+  ansible.builtin.command:
+    cmd: >-
+      {{ devture_systemd_docker_base_host_command_docker }} network create
+      {% if devture_systemd_docker_base_ipv6_enabled %}--ipv6{% endif %}
+      {{ devture_systemd_docker_base_container_networks_driver_options_string }}
+      {{ app_dooropener_container_network }}
+  register: network_creation_result
+  changed_when: network_creation_result.rc == 0
+  failed_when: network_creation_result.rc != 0 and 'already exists' not in network_creation_result.stderr
+
+- name: Ensure app-dooropener systemd service is present
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/systemd/app-dooropener.service.j2"
+    dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ app_dooropener_identifier }}.service"
+    mode: "0644"

--- a/roles/custom/app-dooropener/tasks/main.yml
+++ b/roles/custom/app-dooropener/tasks/main.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+- name: Perform app-dooropener installation tasks
+  when: app_dooropener_enabled | bool
+  tags:
+    - setup-all
+    - setup-app-dooropener
+    - install-all
+    - install-app-dooropener
+  block:
+    - name: Validate app-dooropener configuration
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/validate_config.yml"
+    - name: Install app-dooropener
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/install.yml"
+
+- name: Perform app-dooropener uninstallation tasks
+  when: not app_dooropener_enabled | bool
+  tags:
+    - setup-all
+    - setup-app-dooropener
+  block:
+    - name: Uninstall app-dooropener
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/uninstall.yml"

--- a/roles/custom/app-dooropener/tasks/uninstall.yml
+++ b/roles/custom/app-dooropener/tasks/uninstall.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+- name: Check existence of app-dooropener systemd service
+  ansible.builtin.stat:
+    path: "{{ devture_systemd_docker_base_systemd_path }}/{{ app_dooropener_identifier }}.service"
+  register: app_dooropener_service_stat
+
+- name: Uninstall app-dooropener systemd services and files
+  when: app_dooropener_service_stat.stat.exists | bool
+  block:
+    - name: Ensure app-dooropener systemd service is stopped
+      ansible.builtin.service:
+        name: "{{ app_dooropener_identifier }}"
+        state: stopped
+        enabled: false
+        daemon_reload: true
+
+    - name: Ensure app-dooropener systemd service does not exist
+      ansible.builtin.file:
+        path: "{{ devture_systemd_docker_base_systemd_path }}/{{ app_dooropener_identifier }}.service"
+        state: absent
+
+    - name: Ensure app-dooropener container network does not exist via community.docker.docker_network
+      when: devture_systemd_docker_base_container_network_creation_method == 'ansible-module'
+      community.docker.docker_network:
+        name: "{{ app_dooropener_container_network }}"
+        state: absent
+
+    - name: Ensure app-dooropener container network does not exist via ansible.builtin.command
+      when: devture_systemd_docker_base_container_network_creation_method == 'command'
+      ansible.builtin.command:
+        cmd: >-
+          {{ devture_systemd_docker_base_host_command_docker }} network rm
+          {{ app_dooropener_container_network }}
+      register: network_deletion_result
+      changed_when: app_dooropener_container_network in network_deletion_result.stdout
+
+    - name: Ensure app-dooropener path does not exist
+      ansible.builtin.file:
+        path: "{{ app_dooropener_base_path }}"
+        state: absent

--- a/roles/custom/app-dooropener/tasks/validate_config.yml
+++ b/roles/custom/app-dooropener/tasks/validate_config.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Oliver Lorenz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+- name: Fail if required app-dooropener settings not defined
+  ansible.builtin.fail:
+    msg: >-
+      You need to define a required configuration setting (`{{ item }}`).
+  when: "lookup('vars', item, default='') | string | length == 0"
+  with_items:
+    - app_dooropener_container_network
+    - app_dooropener_environment_homeassistant_token
+    - app_dooropener_config_home_assistant_base_url
+
+- name: Run if Traefik is enabled
+  when: app_dooropener_container_labels_traefik_enabled | bool
+  block:
+    - name: Fail if Traefik settings required for app-dooropener are not defined
+      ansible.builtin.fail:
+        msg: >-
+          You need to define a required configuration setting (`{{ item }}`).
+      when: "lookup('vars', item, default='') | string | length == 0"
+      with_items:
+        - app_dooropener_container_labels_traefik_hostname
+        - app_dooropener_container_labels_traefik_path_prefix

--- a/roles/custom/app-dooropener/templates/config.json.j2
+++ b/roles/custom/app-dooropener/templates/config.json.j2
@@ -1,0 +1,11 @@
+{#
+SPDX-FileCopyrightText: 2026 Oliver Lorenz
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+{{
+  {
+    'homeAssistantBaseUrl': app_dooropener_config_home_assistant_base_url,
+    'doors': app_dooropener_config_doors
+  } | to_nice_json
+}}

--- a/roles/custom/app-dooropener/templates/env.j2
+++ b/roles/custom/app-dooropener/templates/env.j2
@@ -1,0 +1,11 @@
+{#
+SPDX-FileCopyrightText: 2026 Oliver Lorenz
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
+PORT={{ app_dooropener_container_http_port }}
+CONFIG_PATH={{ app_dooropener_container_config_path }}
+HOMEASSISTANT_TOKEN={{ app_dooropener_environment_homeassistant_token }}
+
+{{ app_dooropener_environment_variables_additional_variables }}

--- a/roles/custom/app-dooropener/templates/labels.j2
+++ b/roles/custom/app-dooropener/templates/labels.j2
@@ -1,0 +1,47 @@
+{#
+SPDX-FileCopyrightText: 2026 Oliver Lorenz
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
+{% if app_dooropener_container_labels_traefik_enabled %}
+traefik.enable=true
+
+{% if app_dooropener_container_labels_traefik_docker_network %}
+traefik.docker.network={{ app_dooropener_container_labels_traefik_docker_network }}
+{% endif %}
+
+{% set middlewares = [] %}
+
+{% if app_dooropener_container_labels_traefik_additional_request_headers.keys() | length > 0 %}
+{% for name, value in app_dooropener_container_labels_traefik_additional_request_headers.items() %}
+traefik.http.middlewares.{{ app_dooropener_identifier }}-add-request-headers.headers.customrequestheaders.{{ name }}={{ value }}
+{% endfor %}
+{% set middlewares = middlewares + [app_dooropener_identifier + '-add-request-headers'] %}
+{% endif %}
+
+{% if app_dooropener_container_labels_traefik_additional_response_headers.keys() | length > 0 %}
+{% for name, value in app_dooropener_container_labels_traefik_additional_response_headers.items() %}
+traefik.http.middlewares.{{ app_dooropener_identifier }}-add-response-headers.headers.customresponseheaders.{{ name }}={{ value }}
+{% endfor %}
+{% set middlewares = middlewares + [app_dooropener_identifier + '-add-response-headers'] %}
+{% endif %}
+
+traefik.http.routers.{{ app_dooropener_identifier }}.rule={{ app_dooropener_container_labels_traefik_rule }}
+{% if app_dooropener_container_labels_traefik_priority | int > 0 %}
+traefik.http.routers.{{ app_dooropener_identifier }}.priority={{ app_dooropener_container_labels_traefik_priority }}
+{% endif %}
+traefik.http.routers.{{ app_dooropener_identifier }}.service={{ app_dooropener_identifier }}
+{% if middlewares | length > 0 %}
+traefik.http.routers.{{ app_dooropener_identifier }}.middlewares={{ middlewares | join(',') }}
+{% endif %}
+traefik.http.routers.{{ app_dooropener_identifier }}.entrypoints={{ app_dooropener_container_labels_traefik_entrypoints }}
+traefik.http.routers.{{ app_dooropener_identifier }}.tls={{ app_dooropener_container_labels_traefik_tls | to_json }}
+{% if app_dooropener_container_labels_traefik_tls %}
+traefik.http.routers.{{ app_dooropener_identifier }}.tls.certResolver={{ app_dooropener_container_labels_traefik_tls_certResolver }}
+{% endif %}
+
+traefik.http.services.{{ app_dooropener_identifier }}.loadbalancer.server.port={{ app_dooropener_container_http_port }}
+{% endif %}
+
+{{ app_dooropener_container_labels_additional_labels }}

--- a/roles/custom/app-dooropener/templates/systemd/app-dooropener.service.j2
+++ b/roles/custom/app-dooropener/templates/systemd/app-dooropener.service.j2
@@ -1,0 +1,57 @@
+{#
+SPDX-FileCopyrightText: 2026 Oliver Lorenz
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
+[Unit]
+Description=Dooropener PWA ({{ app_dooropener_identifier }})
+{% for service in app_dooropener_systemd_required_services_list %}
+Requires={{ service }}
+After={{ service }}
+{% endfor %}
+{% for service in app_dooropener_systemd_wanted_services_list %}
+Wants={{ service }}
+{% endfor %}
+DefaultDependencies=no
+
+[Service]
+Type=simple
+Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ app_dooropener_identifier }} 2>/dev/null || true'
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ app_dooropener_identifier }} 2>/dev/null || true'
+
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
+      --rm \
+      --name={{ app_dooropener_identifier }} \
+      --log-driver=none \
+      --cap-drop=ALL \
+      --network={{ app_dooropener_container_network }} \
+      {% if app_dooropener_container_http_host_bind_port %}
+      -p {{ app_dooropener_container_http_host_bind_port }}:{{ app_dooropener_container_http_port }} \
+      {% endif %}
+      --env-file={{ app_dooropener_base_path }}/env \
+      --label-file={{ app_dooropener_base_path }}/labels \
+      {% for volume in app_dooropener_container_additional_volumes %}
+      --mount type={{ volume.type | default('bind' if '/' in volume.src else 'volume') }},src={{ volume.src }},dst={{ volume.dst }}{{ (',' + volume.options) if volume.options else '' }} \
+      {% endfor %}
+      {% for arg in app_dooropener_container_extra_arguments %}
+      {{ arg }} \
+      {% endfor %}
+      {{ app_dooropener_container_image }}
+
+{% for network in app_dooropener_container_additional_networks %}
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ app_dooropener_identifier }}
+{% endfor %}
+
+ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ app_dooropener_identifier }}
+
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ app_dooropener_identifier }} 2>/dev/null || true'
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ app_dooropener_identifier }} 2>/dev/null || true'
+
+Restart=always
+RestartSec=30
+SyslogIdentifier={{ app_dooropener_identifier }}
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -541,6 +541,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (gowa_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'gowa']} if gowa_enabled else omit) }}
   # /role-specific:gowa
 
+  # role-specific:app-dooropener
+  - |-
+    {{ ({'name': (app_dooropener_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'app-dooropener']} if app_dooropener_enabled else omit) }}
+  # /role-specific:app-dooropener
+
   # role-specific:grafana
   - |-
     {{ ({'name': (grafana_identifier + '.service'), 'priority': 2000, 'restart_necessary': (grafana_restart_necessary | bool), 'groups': ['mash', 'grafana']} if grafana_enabled else omit) }}
@@ -7119,6 +7124,33 @@ gowa_gid: "{{ mash_playbook_gid }}"
 #                                                                      #
 ########################################################################
 # /role-specific:gowa
+
+# role-specific:app-dooropener
+########################################################################
+#                                                                      #
+# app-dooropener                                                      #
+#                                                                      #
+########################################################################
+
+app_dooropener_enabled: false
+
+app_dooropener_uid: "{{ mash_playbook_uid }}"
+app_dooropener_gid: "{{ mash_playbook_gid }}"
+
+app_dooropener_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+app_dooropener_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+app_dooropener_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+app_dooropener_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+
+########################################################################
+#                                                                      #
+# /app-dooropener                                                     #
+#                                                                      #
+########################################################################
+# /role-specific:app-dooropener
 
 # role-specific:grafana
 ########################################################################

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -434,6 +434,10 @@
     - role: custom/gowa
     # /role-specific:gowa
 
+    # role-specific:app-dooropener
+    - role: custom/app-dooropener
+    # /role-specific:app-dooropener
+
     # role-specific:grafana
     - role: galaxy/grafana
     # /role-specific:grafana


### PR DESCRIPTION
## What changed and why

Adds a new custom Ansible role (`roles/custom/app-dooropener`) that deploys the [Dooropener PWA](https://github.com/oliverlorenz/app-dooropener) as a Docker container behind Traefik, following the same pattern as the existing `oliverlorenz-api` and `gowa` custom roles.

- `ghcr.io/oliverlorenz/app-dooropener:latest` image, systemd-wrapped container, `docker network` per service, standard `env`/`labels` template pair.
- `app_dooropener_config_doors` (list of `{doorId, scriptId, pins: [{pin, validFrom, validUntil}]}`) is rendered into `config.json` via a new `config.json.j2` template and bind-mounted read-only into the container at `app_dooropener_container_config_path`. PIN rotation is then just a playbook re-run + container restart, no image rebuild — matches how the app itself expects to be configured (`CONFIG_PATH` env var).
- `validate_config.yml` fails fast if `app_dooropener_environment_homeassistant_token`, `app_dooropener_config_home_assistant_base_url`, or (when Traefik is enabled) the hostname/path prefix aren't set.
- Wired into `templates/setup.yml` (play) and `templates/group_vars_mash_servers` (systemd status registration + uid/gid/Traefik-network/entrypoint overrides), right alongside the other custom roles.
- Role `README.md` documents the required variables and the vault-for-secrets convention (token + PINs shouldn't live in plain `group_vars`).

This depends on [oliverlorenz/app-dooropener#29](https://github.com/oliverlorenz/app-dooropener/pull/29), which adds the Dockerfile and the GHCR publish workflow this role's `app_dooropener_container_image` points at — that image doesn't exist yet until that PR is merged and a release is cut.

Closes oliverlorenz/app-dooropener#17

Verified locally (no live Ansible run — this container has no ansible/ansible-lint installed and no test inventory):
- `yamllint roles/custom/app-dooropener` — clean
- `reuse lint` — compliant (416/416 files)
- `codespell` — clean
- All four Jinja templates parse without syntax errors
- `markdownlint` (repo's config/rule set) on the new README — clean

## Checklist

- [x] Role follows the existing `custom/oliverlorenz-api` structure (`meta`, `defaults`, `tasks/{main,install,uninstall,validate_config}`, `templates`)
- [x] `templates/setup.yml` and `templates/group_vars_mash_servers` updated with matching `role-specific:` markers
- [x] SPDX headers on all new files, `REUSE.toml` annotation for `meta/main.yml`
- [ ] Not yet run against a real server — worth a dry-run (`just setup-service app-dooropener <server> --check`) before enabling in production
