### PR TITLE
fix(ci): resolve prek failures on main

### DIFF
--- a/bin/sync-deploy-workflow-options.py
+++ b/bin/sync-deploy-workflow-options.py
@@ -16,9 +16,13 @@ WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
 
 def get_ready_hosts():
+    hosts_path = REPO_ROOT / "inventory" / "hosts"
+    if not hosts_path.is_file():
+        return None
+
     hosts = []
     in_group = False
-    for line in (REPO_ROOT / "inventory" / "hosts").read_text().splitlines():
+    for line in hosts_path.read_text().splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
@@ -114,6 +118,14 @@ def replace_generated_block(text, marker, items):
 
 def main():
     hosts = get_ready_hosts()
+
+    if hosts is None:
+        print(
+            "inventory/hosts not found -- skipping "
+            "(this check requires a local checkout of the private inventory submodule).",
+        )
+        return 0
+
     services = get_enabled_services()
 
     if not hosts:

--- a/roles/custom/gowa/.codespellrc
+++ b/roles/custom/gowa/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words-list = statics

--- a/roles/custom/gowa/REUSE.toml
+++ b/roles/custom/gowa/REUSE.toml
@@ -8,6 +8,7 @@ version = 1
 [[annotations]]
 path = [
     ".ansible-lint",
+    ".codespellrc",
     ".github/renovate.json",
     ".github/workflows/pre-commit.yml",
     ".gitignore",

--- a/roles/custom/gowa/defaults/main.yml
+++ b/roles/custom/gowa/defaults/main.yml
@@ -64,7 +64,7 @@ gowa_container_environment_debug:
 gowa_container_environment_app_os: Bridge
 gowa_container_environment_basic_auth_user: admin
 gowa_container_environment_basic_auth_password: admin
-gowa_container_environment_base_path: "{{ gowa_path_prefix}}"
+gowa_container_environment_base_path: "{{ gowa_path_prefix }}"
 gowa_container_environment_db_uri:
 gowa_container_environment_auto_mark_read:
 gowa_container_environment_webhook:

--- a/roles/custom/gowa/handlers/main.yml
+++ b/roles/custom/gowa/handlers/main.yml
@@ -4,7 +4,7 @@
 
 ---
 - name: Restart GOWA
-  ansible.builtin.command:
-    cmd: "systemctl try-restart {{ gowa_identifier }}.service"
+  ansible.builtin.systemd:
+    name: "{{ gowa_identifier }}.service"
+    state: restarted
   listen: "gowa-restart"
-  changed_when: false

--- a/roles/custom/gowa/tasks/install.yml
+++ b/roles/custom/gowa/tasks/install.yml
@@ -27,7 +27,6 @@
     - "{{ gowa_statics_path }}/senditems"
     - "{{ gowa_statics_path }}/media"
 
-
 - name: Ensure GOWA support files installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"


### PR DESCRIPTION
## Summary
- `sync-deploy-workflow-options`: skip gracefully (exit 0) instead of crashing when `inventory/hosts` isn't present — it's a private submodule that's never checked out in public CI, so the hook always failed there. Introduced by #791.
- `roles/custom/gowa`: pre-existing lint breakage unrelated to #791, surfaced by the same CI run — allow-list `statics` for codespell (real GOWA data dir, not a typo), fix Jinja2 spacing, replace raw `systemctl` command with the `ansible.builtin.systemd` module, drop a stray blank line.

Fixes: https://github.com/oliverlorenz/mash-playbook/actions/runs/31014777090/job/92335863869

## Test plan
- [x] `codespell`, `ansible-lint --profile production`, `reuse lint` all pass for `roles/custom/gowa`
- [x] `sync-deploy-workflow-options.py` verified against real local inventory (no-op, still up to date) and with `inventory/hosts` removed (skips cleanly, exit 0)
- [x] Full `prek` suite passed via the pre-push hook