### PR TITLE
feat(ci): support all-hosts rollout for deploy/rollback setup-all

### DIFF
--- a/.github/workflows/deploy-run-setup-all.yml
+++ b/.github/workflows/deploy-run-setup-all.yml
@@ -5,7 +5,10 @@
 ---
 # Reusable deploy step, split out of deploy-setup-all.yml so the same checkout/prepare/deploy
 # logic can be called from three places: the initial deploy and the auto-rollback job in
-# deploy-setup-all.yml, plus the manual rollback in rollback-setup-all.yml.
+# deploy-setup-all.yml, plus the manual rollback in rollback-setup-all.yml. `rollback: true`
+# resolves the deployed/<host> tag itself (rather than the caller passing a resolved sha) so
+# each host in a deploy-setup-all.yml matrix run resolves independently -- job outputs can't
+# be fanned out per-matrix-instance to a downstream job in GitHub Actions.
 name: Deploy run (setup-all)
 
 on:
@@ -15,9 +18,14 @@ on:
         required: true
         type: string
       ref:
-        description: mash-playbook ref to deploy. Empty deploys the ref this workflow run started from.
+        description: mash-playbook ref to deploy. Empty deploys the ref this workflow run started from. Ignored when `rollback` is true.
         required: false
         type: string
+      rollback:
+        description: If true, ignore `ref` and deploy the last known-good ref recorded for this host (refs/tags/deployed/<host>).
+        required: false
+        type: boolean
+        default: false
     outputs:
       deployed_sha:
         description: Commit SHA of mash-playbook that was deployed
@@ -34,13 +42,27 @@ jobs:
       deployed_sha: ${{ steps.prepare.outputs.deployed_sha }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Rollback needs full history to resolve the deployed/<host> tag below.
+          fetch-depth: ${{ inputs.rollback && 0 || 1 }}
+
+      - name: Resolve last known-good ref
+        id: resolve-rollback
+        if: inputs.rollback
+        run: |
+          if git rev-parse -q --verify "refs/tags/deployed/${{ inputs.host }}" >/dev/null; then
+            echo "sha=$(git rev-parse "refs/tags/deployed/${{ inputs.host }}")" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::No previously successful deploy recorded for host '${{ inputs.host }}' -- nothing to roll back to."
+            exit 1
+          fi
 
       - name: Prepare
         id: prepare
         uses: ./.github/actions/deploy-prepare
         with:
           host: ${{ inputs.host }}
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.rollback && steps.resolve-rollback.outputs.sha || inputs.ref }}
           gh_pat: ${{ secrets.GH_PAT }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
           inventory_secrets: ${{ secrets.INVENTORY_SECRETS }}

--- a/.github/workflows/deploy-setup-all.yml
+++ b/.github/workflows/deploy-setup-all.yml
@@ -6,20 +6,21 @@
 # Entry point (user-triggered). Orchestrates deploy -> record known-good -> approval-gated
 # auto-rollback. The actual deploy step is factored out to deploy-run-setup-all.yml so it
 # can be reused here for both the initial deploy (below) and the rollback job.
+#
+# Leaving `host` empty targets every host in the mash_servers inventory group, fanned out as
+# a parallel matrix (resolve-hosts below resolves the group via ansible-inventory). A single
+# host still targets just that host. record-rollback-success is intentionally not present:
+# rollback redeploys exactly the sha the deployed/<host> tag already points to, so re-tagging
+# it afterwards would be a no-op.
 name: Deploy - setup-all
 
 on:
   workflow_dispatch:
     inputs:
       host:
-        description: Target host
-        required: true
-        type: choice
-        options:
-          # BEGIN GENERATED: hosts
-          - mash.oliverlorenz.com
-          # END GENERATED: hosts
-        default: mash.oliverlorenz.com
+        description: Target host. Leave empty to deploy to every host in mash_servers.
+        required: false
+        type: string
       ref:
         description: mash-playbook ref (branch, tag, or commit) to deploy. Leave empty to deploy the ref this workflow is run from.
         required: false
@@ -29,21 +30,68 @@ permissions:
   contents: write
 
 jobs:
+  resolve-hosts:
+    name: Resolve target hosts
+    runs-on: ubuntu-latest
+    outputs:
+      hosts: ${{ steps.resolve.outputs.hosts }}
+    steps:
+      - uses: actions/checkout@v4
+        if: inputs.host == ''
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Resolve pinned inventory commit
+        id: inventory
+        if: inputs.host == ''
+        run: echo "sha=$(git rev-parse HEAD:inventory)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout inventory
+        if: inputs.host == ''
+        uses: actions/checkout@v4
+        with:
+          repository: oliverlorenz/mash-inventories
+          token: ${{ secrets.GH_PAT }}
+          path: inventory
+          ref: ${{ steps.inventory.outputs.sha }}
+
+      - name: Install Ansible
+        if: inputs.host == ''
+        run: pip install ansible regex
+
+      - name: Resolve hosts
+        id: resolve
+        run: |
+          if [ -n "${{ inputs.host }}" ]; then
+            echo 'hosts=["${{ inputs.host }}"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "hosts=$(ansible-inventory -i inventory/hosts --list | jq -c '.mash_servers.hosts')" >> "$GITHUB_OUTPUT"
+          fi
+
   deploy:
-    name: Deploy
+    name: Deploy (${{ matrix.host }})
+    needs: resolve-hosts
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJson(needs.resolve-hosts.outputs.hosts) }}
     uses: ./.github/workflows/deploy-run-setup-all.yml
     with:
-      host: ${{ inputs.host }}
+      host: ${{ matrix.host }}
       ref: ${{ inputs.ref }}
     secrets: inherit
 
   record-success:
-    name: Record last known-good ref
-    needs: deploy
+    name: Record last known-good ref (${{ matrix.host }})
+    needs: [resolve-hosts, deploy]
     if: needs.deploy.result == 'success'
+    strategy:
+      matrix:
+        host: ${{ fromJson(needs.resolve-hosts.outputs.hosts) }}
     uses: ./.github/workflows/record-deployed-ref.yml
     with:
-      host: ${{ inputs.host }}
+      host: ${{ matrix.host }}
+      # Same ref is deployed to every host, so every matrix instance resolves the same sha.
       sha: ${{ needs.deploy.outputs.deployed_sha }}
     secrets: inherit
 
@@ -53,39 +101,19 @@ jobs:
     if: failure()
     environment: rollback-approval
     runs-on: ubuntu-latest
-    outputs:
-      sha: ${{ steps.resolve.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Resolve last known-good ref
-        id: resolve
-        run: |
-          if git rev-parse -q --verify "refs/tags/deployed/${{ inputs.host }}" >/dev/null; then
-            echo "sha=$(git rev-parse "refs/tags/deployed/${{ inputs.host }}")" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error::No previously successful deploy recorded for host '${{ inputs.host }}' -- nothing to roll back to."
-            exit 1
-          fi
+      - run: echo "Approved -- proceeding with rollback of all targeted hosts."
 
   rollback:
-    name: Auto-rollback (${{ inputs.host }})
-    needs: await-rollback-approval
+    name: Auto-rollback (${{ matrix.host }})
+    needs: [resolve-hosts, await-rollback-approval]
     if: always() && needs.await-rollback-approval.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJson(needs.resolve-hosts.outputs.hosts) }}
     uses: ./.github/workflows/deploy-run-setup-all.yml
     with:
-      host: ${{ inputs.host }}
-      ref: ${{ needs.await-rollback-approval.outputs.sha }}
-    secrets: inherit
-
-  record-rollback-success:
-    name: Record last known-good ref (post-rollback)
-    needs: rollback
-    if: always() && needs.rollback.result == 'success'
-    uses: ./.github/workflows/record-deployed-ref.yml
-    with:
-      host: ${{ inputs.host }}
-      sha: ${{ needs.rollback.outputs.deployed_sha }}
+      host: ${{ matrix.host }}
+      rollback: true
     secrets: inherit

--- a/.github/workflows/rollback-setup-all.yml
+++ b/.github/workflows/rollback-setup-all.yml
@@ -5,6 +5,9 @@
 ---
 # Manual rollback entry point. Reuses deploy-run-setup-all.yml (the same job the normal
 # deploy uses) so rolling back is just "deploy an older ref".
+#
+# Leaving `host` empty rolls back every host in mash_servers in parallel (resolve-hosts below
+# resolves the group via ansible-inventory), all to the same explicit `ref`.
 name: Rollback - setup-all
 
 on:
@@ -15,33 +18,76 @@ on:
         required: true
         type: string
       host:
-        description: Target host
-        required: true
-        type: choice
-        options:
-          # BEGIN GENERATED: hosts
-          - mash.oliverlorenz.com
-          # END GENERATED: hosts
-        default: mash.oliverlorenz.com
+        description: Target host. Leave empty to roll back every host in mash_servers.
+        required: false
+        type: string
 
 permissions:
   contents: write
 
 jobs:
+  resolve-hosts:
+    name: Resolve target hosts
+    runs-on: ubuntu-latest
+    outputs:
+      hosts: ${{ steps.resolve.outputs.hosts }}
+    steps:
+      - uses: actions/checkout@v4
+        if: inputs.host == ''
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Resolve pinned inventory commit
+        id: inventory
+        if: inputs.host == ''
+        run: echo "sha=$(git rev-parse HEAD:inventory)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout inventory
+        if: inputs.host == ''
+        uses: actions/checkout@v4
+        with:
+          repository: oliverlorenz/mash-inventories
+          token: ${{ secrets.GH_PAT }}
+          path: inventory
+          ref: ${{ steps.inventory.outputs.sha }}
+
+      - name: Install Ansible
+        if: inputs.host == ''
+        run: pip install ansible regex
+
+      - name: Resolve hosts
+        id: resolve
+        run: |
+          if [ -n "${{ inputs.host }}" ]; then
+            echo 'hosts=["${{ inputs.host }}"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "hosts=$(ansible-inventory -i inventory/hosts --list | jq -c '.mash_servers.hosts')" >> "$GITHUB_OUTPUT"
+          fi
+
   rollback:
-    name: Rollback to ${{ inputs.ref }}
+    name: Rollback to ${{ inputs.ref }} (${{ matrix.host }})
+    needs: resolve-hosts
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJson(needs.resolve-hosts.outputs.hosts) }}
     uses: ./.github/workflows/deploy-run-setup-all.yml
     with:
-      host: ${{ inputs.host }}
+      host: ${{ matrix.host }}
       ref: ${{ inputs.ref }}
     secrets: inherit
 
   record-success:
-    name: Record last known-good ref
-    needs: rollback
+    name: Record last known-good ref (${{ matrix.host }})
+    needs: [resolve-hosts, rollback]
     if: success()
+    strategy:
+      matrix:
+        host: ${{ fromJson(needs.resolve-hosts.outputs.hosts) }}
     uses: ./.github/workflows/record-deployed-ref.yml
     with:
-      host: ${{ inputs.host }}
+      host: ${{ matrix.host }}
+      # Same explicit ref is rolled back to on every host, so every matrix instance resolves
+      # the same sha.
       sha: ${{ needs.rollback.outputs.deployed_sha }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- `host` is now optional on `deploy-setup-all.yml` and `rollback-setup-all.yml` -- leaving it empty targets every host in the `mash_servers` inventory group instead of a single one.
- Empty host resolves the group via `ansible-inventory` in a new `resolve-hosts` job, then fans deploy/record/rollback out as a parallel matrix (`fail-fast: false` so one host's failure doesn't cancel the others).
- `deploy-run-setup-all.yml` gained a `rollback` input so each matrixed host resolves its own `deployed/<host>` tag independently, instead of relying on a shared upstream job's output (which GitHub Actions can't fan out per-matrix-instance to a downstream job).
- Dropped `record-rollback-success` from `deploy-setup-all.yml`: rollback redeploys exactly the sha its tag already points to, so re-tagging afterward was already a no-op.

## Test plan
- [x] `pre-commit run` (yamllint, ansible-lint, sync-deploy-workflow-options) passes on all changed files
- [x] YAML parses cleanly for all three workflow files
- [ ] Manual dry run: trigger `Deploy - setup-all` with a single `host` to confirm unchanged single-host behavior
- [ ] Manual dry run: trigger `Deploy - setup-all` with `host` empty to confirm the matrix fans out to all `mash_servers` hosts in parallel
- [ ] Manual dry run: force a failure and confirm the approval-gated auto-rollback rolls back every targeted host

🤖 Generated with [Claude Code](https://claude.com/claude-code)